### PR TITLE
New registers and Remko App support

### DIFF
--- a/custom_components/remko_mqtt/remko_regs.py
+++ b/custom_components/remko_mqtt/remko_regs.py
@@ -6,8 +6,7 @@ FIELD_MINVALUE = 3
 FIELD_MAXVALUE = 4
 
 # Query list
-query_list = []  # [1079, 1082, 1893, 1894, 1951, 5001, 5032, 5039, 5055, 5085, 5131, 5320, 5693]
-
+query_list = [1079, 1082, 1893, 1894, 1951, 1972, 1974, 5001, 5032, 5039, 5051, 5055, 5085, 5131, 5320, 5321, 5693]
 
 # Register as sensors
 reg_id = {
@@ -16,14 +15,18 @@ reg_id = {
     "water_temp_req": ["1082", "temperature_input", "ºC", 20.0, 60.0],
     "absence_mode": ["1893", "switch", "", "", ""],
     "party_mode": ["1894", "switch", "", "", ""],
+    "fixed_value": ["1972", "switch", "", "", ""],
+    "fixed_value_temp_req": ["1974", "temperature_input", "ºC", 20.0, 60.0],
     "main_mode": ["1951", "select_input", "", "", ""],
     "opmode": ["5001", "sensor_mode", "", "", ""],
+    "heat_gen_status": ["5051", "sensor_mode", "", "", ""],
     "out_temp": ["5032", "temperature", "ºC", 0, 40],
     "mixed_temp": ["5055", "temperature", "ºC", 0, 40],
     "water_temp": ["5039", "temperature", "ºC", 0, 70],
-    "buffer_temp_req": ["5085", "temperature_input", "ºC", 20.0, 60.0],
+    "buffer_temp_target": ["5085", "temperature", "ºC", 0, 70],
     "buffer_temp": ["5131", "temperature", "ºC", 0, 70],
     "el_consumption": ["5320", "sensor_el", "W", 0, 6000],
+    "th_consumption": ["5321", "sensor_el", "W", 0, 20000],
     "dhw_heating": ["5693", "action", "", "", ""],
     "communication_status": ["communication_status", "generated_sensor", "", 0, 0],
 }
@@ -32,17 +35,21 @@ reg_id = {
 #  ['en', 'de']
 id_names = {
     "water_temp_req": ["Water temp. req.", "Warmwasser soll"],
-    "buffer_temp_req": ["Buffer temp. req.", "Heizwasser soll"],
+    "buffer_temp_target": ["Buffer temp. target", "Heizwasser Soll"],
+    "fixed_value_temp_req": ["Fixed value", "Festwert"],
     "out_temp": ["Outside temp.", "Außentemperatur"],
     "mixed_temp": ["Mixed temp.", "Gemischte Temperatur"],
     "water_temp": ["Water temp.", "Warmwasser Temp."],
     "buffer_temp": ["Buffer temp.", "Heizwasser Temp."],
     "el_consumption": ["Electr. power", "Leistung elektrisch"],
+    "th_consumption": ["Therm. power", "Leistung thermisch"],
     "main_mode": ["Room climate mode", "Raumklima Modus"],
     "opmode": ["Operating mode", "Betriebsmodus"],
+    "heat_gen_status": ["Heat generator status", "Wärmeerzeuger Status"],
     "dhw_opmode": ["DHW mode", "WW Modus"],
     "absence_mode": ["Absence mode", "Abwesenheitssmodus"],
     "party_mode": ["Party mode", "Partymodus"],
+    "fixed_value": ["Fixed value", "Festwert"],
     "dhw_heating": ["1x DHW heating", "1x WW aufheizen"],
     "mode1": ["Auto", "Auto"],
     "mode2": ["Heating", "Heizen"],
@@ -68,4 +75,6 @@ id_names = {
     "opmode14": ["Blocking signal", "Sperrsignal"],
     "opmode15": ["Hygiene function", "Hygienefunktion"],
     "opmode16": ["Silent mode", "Silent Modus"],
+    "heatgenstatus0": ["OFF", "Aus"],
+    "heatgenstatus1": ["ON", "An"]
 }

--- a/custom_components/remko_mqtt/remko_regs.py
+++ b/custom_components/remko_mqtt/remko_regs.py
@@ -6,7 +6,7 @@ FIELD_MINVALUE = 3
 FIELD_MAXVALUE = 4
 
 # Query list
-query_list = []  # [1079, 1082, 1893, 1894, 1951, 5001, 5032, 5039, 5320, 5693]
+query_list = []  # [1079, 1082, 1893, 1894, 1951, 5001, 5032, 5039, 5085, 5131, 5320, 5693]
 
 
 # Register as sensors
@@ -20,6 +20,8 @@ reg_id = {
     "opmode": ["5001", "sensor_mode", "", "", ""],
     "out_temp": ["5032", "temperature", "ºC", 0, 40],
     "water_temp": ["5039", "temperature", "ºC", 0, 70],
+    "buffer_temp_req": ["5085", "temperature_input", "ºC", 20.0, 60.0],
+    "buffer_temp": ["5131", "temperature", "ºC", 0, 70],
     "el_consumption": ["5320", "sensor_el", "W", 0, 6000],
     "dhw_heating": ["5693", "action", "", "", ""],
     "communication_status": ["communication_status", "generated_sensor", "", 0, 0],
@@ -29,8 +31,10 @@ reg_id = {
 #  ['en', 'de']
 id_names = {
     "water_temp_req": ["Water temp. req.", "Warmwasser soll"],
+    "buffer_temp_req": ["Buffer temp. req.", "Heizwasser soll"],
     "out_temp": ["Outside temp.", "Außentemperatur"],
     "water_temp": ["Water temp.", "Warmwasser Temp."],
+    "buffer_temp": ["Buffer temp.", "Heizwasser Temp."],
     "el_consumption": ["Electr. power", "Leistung elektrisch"],
     "main_mode": ["Room climate mode", "Raumklima Modus"],
     "opmode": ["Operating mode", "Betriebsmodus"],

--- a/custom_components/remko_mqtt/remko_regs.py
+++ b/custom_components/remko_mqtt/remko_regs.py
@@ -6,7 +6,7 @@ FIELD_MINVALUE = 3
 FIELD_MAXVALUE = 4
 
 # Query list
-query_list = []  # [1079, 1082, 1893, 1894, 1951, 5001, 5032, 5039, 5085, 5131, 5320, 5693]
+query_list = []  # [1079, 1082, 1893, 1894, 1951, 5001, 5032, 5039, 5055, 5085, 5131, 5320, 5693]
 
 
 # Register as sensors
@@ -19,6 +19,7 @@ reg_id = {
     "main_mode": ["1951", "select_input", "", "", ""],
     "opmode": ["5001", "sensor_mode", "", "", ""],
     "out_temp": ["5032", "temperature", "ºC", 0, 40],
+    "mixed_temp": ["5055", "temperature", "ºC", 0, 40],
     "water_temp": ["5039", "temperature", "ºC", 0, 70],
     "buffer_temp_req": ["5085", "temperature_input", "ºC", 20.0, 60.0],
     "buffer_temp": ["5131", "temperature", "ºC", 0, 70],
@@ -33,6 +34,7 @@ id_names = {
     "water_temp_req": ["Water temp. req.", "Warmwasser soll"],
     "buffer_temp_req": ["Buffer temp. req.", "Heizwasser soll"],
     "out_temp": ["Outside temp.", "Außentemperatur"],
+    "mixed_temp": ["Mixed temp.", "Gemischte Temperatur"],
     "water_temp": ["Water temp.", "Warmwasser Temp."],
     "buffer_temp": ["Buffer temp.", "Heizwasser Temp."],
     "el_consumption": ["Electr. power", "Leistung elektrisch"],

--- a/custom_components/remko_mqtt/remko_regs.py
+++ b/custom_components/remko_mqtt/remko_regs.py
@@ -6,7 +6,7 @@ FIELD_MINVALUE = 3
 FIELD_MAXVALUE = 4
 
 # Query list
-query_list = [1079, 1082, 1893, 1894, 1951, 1972, 1974, 5001, 5032, 5039, 5051, 5055, 5085, 5131, 5320, 5321, 5693]
+query_list = [1079, 1082, 1893, 1894, 1951, 1972, 1974, 5001, 5032, 5027, 5039, 5051, 5055, 5085, 5131, 5320, 5321, 5693]
 
 # Register as sensors
 reg_id = {
@@ -25,6 +25,7 @@ reg_id = {
     "water_temp": ["5039", "temperature", "ºC", 0, 70],
     "buffer_temp_target": ["5085", "temperature", "ºC", 0, 70],
     "buffer_temp": ["5131", "temperature", "ºC", 0, 70],
+    "circulation_temp": ["5027", "temperature", "ºC", 0, 70],
     "el_consumption": ["5320", "sensor_el", "W", 0, 6000],
     "th_consumption": ["5321", "sensor_el", "W", 0, 20000],
     "dhw_heating": ["5693", "action", "", "", ""],
@@ -41,6 +42,7 @@ id_names = {
     "mixed_temp": ["Mixed temp.", "Gemischte Temperatur"],
     "water_temp": ["Water temp.", "Warmwasser Temp."],
     "buffer_temp": ["Buffer temp.", "Heizwasser Temp."],
+    "circulation_temp": ["Circulation temp.", "Zirkulation Temp."],
     "el_consumption": ["Electr. power", "Leistung elektrisch"],
     "th_consumption": ["Therm. power", "Leistung thermisch"],
     "main_mode": ["Room climate mode", "Raumklima Modus"],

--- a/custom_components/remko_mqtt/sensor.py
+++ b/custom_components/remko_mqtt/sensor.py
@@ -203,4 +203,8 @@ class HeatPumpSensor(SensorEntity):
     @property
     def device_class(self):
         """Return the class of this device."""
+        if self._unit == UnitOfTemperature.CELSIUS:
+            return "temperature"
+        if self._unit == "W":
+            return "power"
         return f"{DOMAIN}_HeatPumpSensor"


### PR DESCRIPTION
Added thermal consumption 5321
Added fixed value 1972 and 1974
Added status of additional heater 5051 (for hybrid gas system)

Support parallel use of Remko App
User has 120 s to make changes by Remko App
Custom component sends refresh only for 120 s
Only every 120 s query list is sent
Remko App sends CLIENT2HOST with CLIENT_ID included
